### PR TITLE
Add baseurl as prefix for the favicon path

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -21,14 +21,14 @@
         {{ end }}
 
     <!-- Favicons - https://realfavicongenerator.net/ -->
-    <link rel="apple-touch-icon" sizes="180x180" href="/img/favicon/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="/img/favicon/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/img/favicon/favicon-16x16.png">
-    <link rel="manifest" href="/img/favicon/site.webmanifest">
-    <link rel="mask-icon" href="/img/favicon/safari-pinned-tab.svg" color="#000000">
-    <link rel="shortcut icon" href="/img/favicon/favicon.ico">
+    <link rel="apple-touch-icon" sizes="180x180" href="{{ .Site.BaseURL }}img/favicon/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="{{ .Site.BaseURL }}img/favicon/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="{{ .Site.BaseURL }}img/favicon/favicon-16x16.png">
+    <link rel="manifest" href="{{ .Site.BaseURL }}img/favicon/site.webmanifest">
+    <link rel="mask-icon" href="{{ .Site.BaseURL }}img/favicon/safari-pinned-tab.svg" color="#000000">
+    <link rel="shortcut icon" href="{{ .Site.BaseURL }}img/favicon/favicon.ico">
     <meta name="msapplication-TileColor" content="#2b5797">
-    <meta name="msapplication-config" content="/img/favicon/browserconfig.xml">
+    <meta name="msapplication-config" content="{{ .Site.BaseURL }}img/favicon/browserconfig.xml">
     <meta name="theme-color" content="#ffffff">
     
     <!-- Twitter Cards - https://xvrdm.github.io/2017/10/23/socialize-your-blogdown/ -->


### PR DESCRIPTION
Hi @nathancday. I am using this template for two projects as GitLab pages. For this reason, the baseURL of the projects are in the form `https://<MYUSER>.gitlab.io/<MYPROJECT>/` (https://rodrigomelo9.gitlab.io/fpgargentina/ and https://rodrigomelo9.gitlab.io/fpgapedia/ to be exact). The proposed modification was performed to support favicons when the site is in a subdirectory such as in these cases. You can see it working [here](https://rodrigomelo9.gitlab.io/fpgargentina/) (with the changes) and not working [here](https://rodrigomelo9.gitlab.io/fpgapedia/) (without the changes).

Regards,
Rodrigo